### PR TITLE
YEL-7394 prevent inactive tableau instance notprod from starting automatically

### DIFF
--- a/ec2_startup.tf
+++ b/ec2_startup.tf
@@ -80,7 +80,16 @@ resource "aws_iam_policy" "ec2_startup" {
                 "s3:GetObject"
             ],
             "Resource": "arn:aws:s3:::s3-dq-httpd-config-bucket-notprod/ssl.conf"
-      }
+        },
+        {
+            "Sid": "AllowKMSDecryption",
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+            ],
+            "Effect": "Allow",
+            "Resource": "${var.kms_key_s3}"
+        }
     ]
 }
 EOF

--- a/lambda/code/ec2_startup.py
+++ b/lambda/code/ec2_startup.py
@@ -19,7 +19,6 @@ def get_ssl_config_file_contents():
         s3_response = s3_object.get()
         s3_object_body = s3_response.get('Body')
         content = s3_object_body.read().decode("utf-8")
-        content_list = content.split("\n")
 
     except s3.meta.client.exceptions.NoSuchBucket as err:
         print('No such bucket')
@@ -46,19 +45,21 @@ def get_ssl_config_file_contents():
         return
 
     else:
-        return content_list
+        ssl_lines = content.split("\n")
 
     finally:
-        return
+        return ssl_lines
 
 
 def get_inactive_notprod_instance_ip(ssl_lines):
-    """Extract ip address from ssl config file"""
+    """Extract ip address from contents of ssl config file"""
     if ssl_lines is None:
         return
 
+    # Regex to extract one of the two notprod ip addresses
+    # Whichever one is on a commented line is the 'inactive' one
     proxy_regex = re.compile(
-        r"^\s*[^#]\s*ProxyPassReverse\s*/\s*http://(?P<inactive_ip>10\.1\.12\.11[12])/\s*$"
+        r"^\s*#\s*ProxyPassReverse\s*/\s*http://(?P<inactive_ip>10\.1\.12\.11[12])/\s*$"
     )
 
     for line in ssl_lines:

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "pipeline_name" {
   default = "daily-tasks"
 }
 
+variable "kms_key_s3" {
+  description = "The ARN of the KMS key that is used to encrypt HTTPD config bucket objects"
+  default     = "arn:aws:kms:eu-west-2:483846886818:key/c3884750-ad4e-4654-a63b-f5009dbc2c59"
+}
+
 variable "pipeline_count" {
   default = 1
 }


### PR DESCRIPTION
Fix regular expression to extract the correct 'inactive' tableau instance ip (i.e. the where it appears on a line commented out with a '#')

Add KMS to policy to allow ec2 startup script to read contents of ssl.conf from httpd bucket, in order to extract the inactive instance ip and allow it to be excluded when the startup happens daily