### PR TITLE
YEL-7394 prevent inactive tableau instance notprod from starting automatically

### DIFF
--- a/lambda/code/ec2_startup.py
+++ b/lambda/code/ec2_startup.py
@@ -84,7 +84,7 @@ def lambda_handler(event, context):
                 Filters=[{'Name': 'tag:Name',
                           'Values': ['ec2-internal-tableau-linux-apps-notprod-dq']},
                          {'Name': 'private-ip-address',
-                          'Values': inactive_notprod_instance_ip}]):
+                          'Values': [inactive_notprod_instance_ip]}]):
             inst_to_exclude.append(instance)
 
     for instance in notprod_instances.instances.filter(


### PR DESCRIPTION
Add square brackets to filter values for tableau instance ip; values must be passed in a list or tuple, even if only a single value.