### PR TITLE
Feature/yel 8783 - Prevent Tableau External NotProd instance starting up

### DIFF
--- a/lambda/code/ec2_startup.py
+++ b/lambda/code/ec2_startup.py
@@ -83,6 +83,14 @@ def get_inactive_notprod_instance_ip(ssl_lines):
     return
 
 
+def get_instance_name(instance):
+    filtered_tags = [
+        d.get("Value") for d in instance.tags if d.get("Key") == "Name"
+    ]
+    instance_name = filtered_tags[0]
+    return instance_name
+
+
 def lambda_handler(event, context):
     # Retrieve EC2 Instances
     notprod_instances = boto3.resource('ec2', region_name=active_region)
@@ -132,9 +140,10 @@ def lambda_handler(event, context):
 
     # Iterate over all instances
     for instance in notprod_instances.instances.all():
-        print("Instance-ID: ", instance.id)
+        instance_name = get_instance_name(instance)
+        print(f"Instance: {instance.id}  |  Name: {instance_name}")
         # Check if it's stopped and not in the exclusion list
         if instance in stopped_instances and instance not in inst_to_exclude:
             # Start the instance
             instance.start()
-            print('Started instance: ', instance.id)
+            print(f"Started : {instance.id}  |  Name: {instance_name}")


### PR DESCRIPTION
- Prevent Tableau External NotProd instance starting up automatically on the daily schedule since it is not actively used for development.
- Remove duplicated iteration over stopped instances
- Add instance names to output for clarity

