### PR TITLE
Update dt_bucket_key Principals to match state

### DIFF
--- a/ec2_startup.tf
+++ b/ec2_startup.tf
@@ -21,8 +21,8 @@ resource "aws_kms_key" "dt_bucket_key" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                  "${data.aws_caller_identity.current.arn}",
-                  "${data.aws_caller_identity.current.account_id}"
+                  "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+                  "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/dq-tf-infra"
                 ]
             },
             "Action": "kms:*",


### PR DESCRIPTION
It would appear that other changes were made directly on the console to satisfy security requirements in YEL-8578.
This change is to made the change in the TF code, so that dq-tf-infra can be run successfully without backing out those new security measures.
see [YEL-8750](https://jira.dsa.homeoffice.gov.uk/browse/YEL-8750?focusedCommentId=533641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-533641)